### PR TITLE
:bug: [Fix] 클라이언트에서 강제 게임종료시 서버 종료되는 버그 해결

### DIFF
--- a/srcs/Client/srcs/rendering.cpp
+++ b/srcs/Client/srcs/rendering.cpp
@@ -201,6 +201,7 @@ void rendering()
         glfwPollEvents();
     }
 
+    glfwDestroyWindow(window);
     glfwTerminate();
 
     std::cout << "[rendering] rendering end\n";

--- a/srcs/Server/includes/Server.hpp
+++ b/srcs/Server/includes/Server.hpp
@@ -32,6 +32,7 @@ struct s_Client
     int waiting_game;
     bool is_game_ing;
     std::string msg;
+    bool is_connected;
 };
 
 struct GameData;
@@ -78,7 +79,7 @@ public:
     /* Socket.cpp */
     void runServer();
     void sendClientMessage(int my_id, enum e_msg flag, char *msg);
-    void sendGameData(e_game flag, int *players_id, GameData *data = nullptr);
+    void sendGameData(e_game flag, s_Client &player, GameData *data = nullptr);
     int receiveGameData(s_Client &player, int &isGameStart);
 };
 

--- a/srcs/Server/srcs/MatchMaking.cpp
+++ b/srcs/Server/srcs/MatchMaking.cpp
@@ -29,7 +29,7 @@ void MatchMaking::matchPlayers()
     if (player1 == nullptr || player2 == nullptr)
         error_msg(FATAL_ERR);
     
-    std::thread *thread = Thread::createThread(playGame, player1, player2); //,check_thread_over); playGame이 종료되었음을 알수있는 변수를 넣고 그변수를 저장하고 있는 스레드에서 핸들링 하고 있다가 join해주게 추가 예정
+    Thread::createThread(playGame, player1, player2); //,check_thread_over); playGame이 종료되었음을 알수있는 변수를 넣고 그변수를 저장하고 있는 스레드에서 핸들링 하고 있다가 join해주게 추가 예정
     //addPlayThread(thread);
     std::cout << "[MatchMaking::matchPlayers] over" << std::endl;
 }

--- a/srcs/Server/srcs/Socket.cpp
+++ b/srcs/Server/srcs/Socket.cpp
@@ -289,7 +289,8 @@ void Server::sendGameData(e_game flag, int *players_id, GameData *data)
             bytes_sent = send(client.fd, data, sizeof(GameData), 0);
             // std::cout << "sendGameData" << std::endl;
             break;
-        default:
+        case GAME_END:
+            data->isGameStart = GAME_END;
             bytes_sent = send(client.fd, data, sizeof(GameData), 0);
             msg = "Game End";
             bytes_sent = send(client.fd, msg.c_str(), msg.size(), 0);

--- a/srcs/Server/srcs/Socket.cpp
+++ b/srcs/Server/srcs/Socket.cpp
@@ -111,7 +111,7 @@ void Server::prepareReadFds(fd_set &read_fds, int &max_fd)
 
     for (int i = 0; i < MAX_CLIENTS; i++)
     {
-        if (clients[i].fd > 0)// && clients[i].is_game_ing == false)
+        if (clients[i].fd > 0) // && clients[i].is_game_ing == false)
         {
             FD_SET(clients[i].fd, &read_fds);
             if (clients[i].fd > max_fd)
@@ -136,6 +136,7 @@ void Server::acceptNewClient(struct sockaddr_in &cli)
             client.buff = nullptr;
             client.waiting_game = 0;
             client.is_game_ing = false;
+            client.is_connected = true;
             sendClientMessage(client.id, ARRIVE, nullptr);
             break;
         }
@@ -266,55 +267,58 @@ void Server::sendClientMessage(int my_id, enum e_msg flag, char *msg)
         std::cout << msg;
 }
 
-void Server::sendGameData(e_game flag, int *players_id, GameData *data)
+void Server::sendGameData(e_game flag, s_Client &player, GameData *data)
 {
-    for (int i = 0; i < 2; i++)
+
+    if (player.is_connected == false)
+        return;
+
+    ssize_t bytes_sent;
+    std::string msg;
+
+    switch (flag)
     {
-        s_Client &client = clients[players_id[i]];
+    case GAME_START:
+        msg = "Game Start";
+        bytes_sent = send(player.fd, msg.c_str(), msg.size(), 0);
+        break;
+    case GAME_LOADING:
+        msg = "Loading...";
+        bytes_sent = send(player.fd, msg.c_str(), msg.size(), 0);
+        break;
+    case GAME_ING:
+        bytes_sent = send(player.fd, data, sizeof(GameData), 0);
+        // std::cout << "sendGameData" << std::endl;
+        break;
+    case GAME_END:
+        data->isGameStart = GAME_END;
+        bytes_sent = send(player.fd, data, sizeof(GameData), 0);
+        msg = "Game End";
+        bytes_sent = send(player.fd, msg.c_str(), msg.size(), 0);
 
-        ssize_t bytes_sent;
-        std::string msg;
+        std::stringstream ss;
+        ss << "[sendGameData] Game End player[" << player.id << "]\n";
+        std::cout << ss.str();
 
-        switch (flag)
-        {
-        case GAME_START:
-            msg = "Game Start";
-            bytes_sent = send(client.fd, msg.c_str(), msg.size(), 0);
-            break;
-        case GAME_LOADING:
-            msg = "Loading...";
-            bytes_sent = send(client.fd, msg.c_str(), msg.size(), 0);
-            break;
-        case GAME_ING:
-            bytes_sent = send(client.fd, data, sizeof(GameData), 0);
-            // std::cout << "sendGameData" << std::endl;
-            break;
-        case GAME_END:
-            data->isGameStart = GAME_END;
-            bytes_sent = send(client.fd, data, sizeof(GameData), 0);
-            msg = "Game End";
-            bytes_sent = send(client.fd, msg.c_str(), msg.size(), 0);
+        break;
+    }
 
-            std::stringstream ss;
-            ss << "[sendGameData] Game End client[" << client.id << "]\n";
-            std::cout << ss.str();
-
-            break;
-        }
-
-        if (bytes_sent == -1)
-        {
-            std::stringstream ss;
-            ss << "[sendGameData] Disconnected client[" << client.id << "]\n";
-            std::cerr << ss.str();
-            Cache::atom_stop = true;
-            return;
-        }
+    if (bytes_sent == -1)
+    {
+        std::stringstream ss;
+        ss << "[sendGameData] Disconnected player[" << player.id << "]\n";
+        std::cerr << ss.str();
+        // Cache::atom_stop = true;
+        player.is_connected = false;
+        return;
     }
 }
 
 int Server::receiveGameData(s_Client &player, int &isGameStart)
 {
+    if (player.is_connected == false)
+        return EXIT_FAILURE;
+
     char buffer[BUFFER_SIZE] = {0};
     std::stringstream ss;
 
@@ -341,6 +345,7 @@ int Server::receiveGameData(s_Client &player, int &isGameStart)
     {
         ss << "[receiveGameData] Failed to receive data from player[" << player.id << "]\n";
         std::cerr << ss.str();
+        player.is_connected = false;
         return EXIT_FAILURE;
     }
 

--- a/srcs/Server/srcs/Util.cpp
+++ b/srcs/Server/srcs/Util.cpp
@@ -33,6 +33,11 @@ void signalHandler(int signum) {
         std::cout << "SIGTERM: Termination signal received" << std::endl;
     else if (signum == SIGPIPE)
     {
+        if (Cache::atom_stop)
+        {
+            std::cout << "SIGPIPE: Broken pipe signal received but already stopped\n";
+            return ;
+        }
         std::cout << "SIGPIPE: Broken pipe signal received\n";
         Cache::atom_stop = true;
         Thread::cleanThread();

--- a/srcs/Server/srcs/Util.cpp
+++ b/srcs/Server/srcs/Util.cpp
@@ -31,18 +31,18 @@ void signalHandler(int signum) {
         std::cout << "SIGINT: Interrupt signal received" << std::endl;
     else if (signum == SIGTERM)
         std::cout << "SIGTERM: Termination signal received" << std::endl;
-    else if (signum == SIGPIPE)
-    {
-        if (Cache::atom_stop)
-        {
-            std::cout << "SIGPIPE: Broken pipe signal received but already stopped\n";
-            return ;
-        }
-        std::cout << "SIGPIPE: Broken pipe signal received\n";
-        Cache::atom_stop = true;
-        Thread::cleanThread();
-        return ;
-    }
+    // else if (signum == SIGPIPE)
+    // {
+    //     if (Cache::atom_stop)
+    //     {
+    //         std::cout << "SIGPIPE: Broken pipe signal received but already stopped\n";
+    //         return ;
+    //     }
+    //     std::cout << "SIGPIPE: Broken pipe signal received\n";
+    //     Cache::atom_stop = true;
+    //     Thread::cleanThread();
+    //     return ;
+    // }
     else
         std::cout << "Others: Signal " << signum << " received" << std::endl;
     cleanMemory();

--- a/srcs/Server/srcs/main.cpp
+++ b/srcs/Server/srcs/main.cpp
@@ -6,7 +6,8 @@ int main(int ac, char **av)
 {
     std::signal(SIGINT, signalHandler); // Ctrl + C
     std::signal(SIGTERM, signalHandler); // kill
-    std::signal(SIGPIPE, signalHandler); //SIGPIPE
+    std::signal(SIGPIPE, SIG_IGN);
+    // std::signal(SIGPIPE, signalHandler); //SIGPIPE
 
     if (!(ac == 2 || ac == 3))
     {


### PR DESCRIPTION
<!--
    PR 제목 형식
    :sparkles: [Feature] 제목
    :hammer: [Refactoring] 제목
    :bug: [Fix] 제목
 -->

 ## 📌 개요 <!-- PR 내용에 대해 축약해서 적어주세요. -->

> 문제

  - 클라이언트에서 강제 게임종료시 서버 종료되는 버그 해결
        - 클라이언트 1개 종료시 SIGPIPE 2번 발동으로 SIGPIPE핸들러에서 cleanThread를 두번해줘서 생긴 에러
 
>해결법
   
  - SIGPIPE를 무시하도록 변경하고 연결끊긴 클라이언트에게는 receive/send를 안하고 게임 정상 진행 후에 꺼지도록 변경

 ## 💻 작업사항 <!-- PR 내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->

- sendGameData: GAME_END 메시지를 보낼떄 data.isGameStart = GAME_END 로직 추가
- rendering.cpp : glfwDestroyWindow(window); 추가 // glfwterminate전에 window destroy
- Server.hpp
    - s_Client::is_connected 추가 // 클라이언트 연결 상태 확인
    - void sendGameData 매개변수 player_id -> s_Client &player 로 변경, 1개스레드 -> 2개스레드 각각 전송
- GameLogic.cpp : threadSendData 매개변수 변경에 따른 수정
- main.cpp : SIGPIPE 무시 코드 추가 // 클라이언트 중도이탈시 서버 종료 방지
- Socket.cpp : sendGameData, recvGameData 수정 // send, recv시 player_id -> player로 변경
- Util.cpp : SIGPIPE 주석처리

- MatchMaking.cpp : 임시 코드, playGame 스레드 추후에 스마트하게 join하도록 변경예정
 ## 💡 이슈 번호 <!-- 관련된 이슈 번호를 적어주세요 (ex. "- close #4242") -->
  - close #20 
