### PR TITLE
:bug: [Fix] 서버에서 게임 강제종료시 메모리 릭 해결

### DIFF
--- a/srcs/Server/Makefile
+++ b/srcs/Server/Makefile
@@ -9,7 +9,7 @@ SERVER_NAME = pong_server
 SERVER_CFLAGS = -Wall -Wextra -Werror -std=c++11
 
 ifeq ($(shell uname -s), Darwin) #MacOS
-LDFLAGS = 
+#LDFLAGS = -pthread 스레드 사용시 추가 해야한다는 지식 공부후 추가예정
 else #Linux 
 LDFLAGS = -lpthread  # for linux
 endif

--- a/srcs/Server/srcs/MatchMaking.cpp
+++ b/srcs/Server/srcs/MatchMaking.cpp
@@ -9,6 +9,9 @@ void playGame(s_Client *player1, s_Client *player2);
 
 int MatchMaking::addPlayThread(std::thread *thread)
 {
+    if (thread == nullptr)
+        return EXIT_FAILURE;
+
     for (int i = 0; i < MAX_THREAD; i++)
     {
         if (_play_thread[i] == nullptr)

--- a/srcs/Server/srcs/Server.cpp
+++ b/srcs/Server/srcs/Server.cpp
@@ -33,6 +33,8 @@ Server::~Server()
         close(serv_fd);
     for (int i = 0; i < MAX_CLIENTS; i++)
     {
+        if (clients[i].buff)
+            delete clients[i].buff;
         if (clients[i].fd > 0)
             close(clients[i].fd);
     }

--- a/srcs/Server/srcs/Socket.cpp
+++ b/srcs/Server/srcs/Socket.cpp
@@ -156,6 +156,9 @@ void Server::handleClientMessage(fd_set &read_fds)
             {
                 std::cout << "Client[" << client.id << "] left" << std::endl;
                 close(client.fd);
+                if (client.buff)
+                    delete client.buff;
+                client.buff = nullptr;
                 client.fd = 0;
                 sendClientMessage(client.id, LEFT, NULL);
             }

--- a/srcs/Server/srcs/Util.cpp
+++ b/srcs/Server/srcs/Util.cpp
@@ -27,6 +27,12 @@ void cleanMemory()
 }
 
 void signalHandler(int signum) {
+    if (Cache::atom_stop)
+    {
+        std::cout << "Signal " << signum << " received but already stopped\n";
+        return ;
+    }
+    
     Cache::atom_stop = true;
     if (signum == SIGINT)
         std::cout << "SIGINT: Interrupt signal received" << std::endl;


### PR DESCRIPTION


<!--
    PR 제목 형식
    :sparkles: [Feature] 제목
    :hammer: [Refactoring] 제목
    :bug: [Fix] 제목
 -->

 ## 📌 개요 <!-- PR 내용에 대해 축약해서 적어주세요. -->
  - 서버에서 게임 강제종료시 메모리 릭 해결

 ## 💻 작업사항 <!-- PR 내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 발생 이유 : 클라이언트에서 ("Game Start\n")를 포함한 메시지 버퍼가 들어왔을 경우 s_Client.buff에 메시지 메모리가 할당 되어 있는데 해제하지 않아서 생긴 누수였음
- 해결 방법 : server클라이언트 소멸시 s_Client.buff 메모리를 해제하도록 수정, 클라이언트 접속 해제시 메모리 해제시

- Makefile : #LDFLAGS = -pthread 스레드 사용시 추가 해야한다는 지식 공부후 추가예정
- MatchMaking.cpp : if (thread == nullptr) 가드 추가
- Server.cpp : 소멸시 s_Client.buff 메모리 해제 추가
- Socket.cpp : 클라이언트 접속 해제시 s_Client.buff 메모리 해제 추가
- Util.cpp : signalHandler 두번 들어올 경우 처리 추가

 ## 💡 이슈 번호 <!-- 관련된 이슈 번호를 적어주세요 (ex. "- close #4242") -->
  - close #23 
